### PR TITLE
Enable nullable reference types.

### DIFF
--- a/MonkeyBot/MonkeyBot.csproj
+++ b/MonkeyBot/MonkeyBot.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
     <ApplicationIcon />
     <OutputTypeEx>exe</OutputTypeEx>
     <StartupObject />
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes #50

- Enables nullable reference types for the entire MonkeyBot project in the .csproj.
- Re-aligns `LangVersion`-property. 

This change produces a lot of warnings (200+) that will need to be looked at. 
I have already started fixing some "low-hanging fruits" around the codebase, but there's potentially a lot of small changes to a lot of files, so it'll be quite a hassle to review. I'll wait with fixing more until further discussion.