### PR TITLE
Fix version conflicts caused by PR#220

### DIFF
--- a/MonkeyBot/MonkeyBot.csproj
+++ b/MonkeyBot/MonkeyBot.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore.Design from 3.1.8 to 5.0.8. [(PR#220)](https://github.com/MarkusKgit/MonkeyBot/pull/220).
Hope this fix can help you.

Best regards,
sucrose