### PR TITLE
Added Unit tests

### DIFF
--- a/MonkeyBot.UnitTests/Modules/CatPics/CatServiceTests.cs
+++ b/MonkeyBot.UnitTests/Modules/CatPics/CatServiceTests.cs
@@ -1,0 +1,130 @@
+﻿using MonkeyBot.Services;
+using MonkeyBot.UnitTests.Utils;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using Xunit;
+
+namespace MonkeyBot.UnitTests.Modules.CatPics
+{
+    public class CatServiceTests
+    {
+        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+        private readonly ICatService catService;
+
+        public CatServiceTests()
+        {
+            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+
+            catService = new CatService(_mockHttpClientFactory.Object);
+        }
+
+        [Theory(DisplayName = "Should return expected Picture Uri for specified breed")]
+        [InlineData("Abyssinian", "abys")]
+        [InlineData("Bengal", "beng")]
+        public async Task GetExpectedPictureUriForSpecifiedBreed(string breed, string breedId)
+        {
+            // Arrange
+            var httpClient = PrepareHttpClient(breed, breedId);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var expectedUri = "https://cdn2.thecatapi.com/images/" + breedId + ".jpg";
+
+            // Act
+            var uri = await catService.GetRandomPictureUrlAsync(breed);
+
+            // Assert
+            Assert.Equal(new Uri(expectedUri), uri);
+        }
+
+        [Theory(DisplayName = "Should return null for specified breed when more than one results are obtained")]
+        [InlineData("Abyssinian", "abys")]
+        [InlineData("Bengal", "beng")]
+        public async Task GetNullPictureUriForSpecifiedBreed(string breed, string breedId)
+        {
+            // Arrange
+            var httpClient = PrepareHttpClient(breed, breedId, 2);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            // Act
+            var uri = await catService.GetRandomPictureUrlAsync(breed);
+
+            // Assert
+            Assert.Null(uri);
+        }
+
+        [Fact(DisplayName = "Should return null for specified breed when API call fails")]
+        public async Task GetNullPictureUriForSpecifiedBreedOnException()
+        {
+            // Act
+            var uri = await catService.GetRandomPictureUrlAsync();
+
+            // Assert
+            Assert.Null(uri);
+        }
+
+        [Fact(DisplayName = "Should return an empty list when API call fails")]
+        public async Task ShouldReturEmptyListOnException()
+        {
+            // Act
+            var breeds = await catService.GetBreedsAsync();
+
+            // Assert
+            Assert.False(breeds.Any());
+        }
+
+        [Fact(DisplayName = "Should return list of breeds")]
+        public async Task ShouldReturnListOfBreeds()
+        {
+            // Arrange
+            var expectedBreeds = new List<string> { "Abyssinian", "Bengal" };
+            var httpClient = PrepareHttpClient(expectedBreeds);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            // Act
+            var breeds = await catService.GetBreedsAsync();
+
+            // Assert
+            Assert.Equal(expectedBreeds, breeds);
+        }
+
+        private HttpClient PrepareHttpClient(string breedName, string breedId, int responseCount = 1)
+        {
+            var baseUri = "https://api.thecatapi.com/v1/";
+            var breedFinderUri = $"{baseUri}breeds/search?q={HttpUtility.UrlEncode(breedName)}";
+            var imageFinderUri = $"{baseUri}images/search?size=small&breed_id={breedId}";
+
+            var mockMessageHandler = new MockResponseHandler();
+            
+            var catBreedResponse = Enumerable.Range(0, responseCount)
+                .Select(c => new CatBreedsResponse(breedId, breedName))
+                .ToList();
+            mockMessageHandler.AddMockResponse(catBreedResponse, breedFinderUri);
+
+            var catImageResponse = Enumerable.Range(0, responseCount)
+                .Select(c => new CatResponse(new Uri("https://cdn2.thecatapi.com/images/" + breedId + ".jpg")))
+                .ToList();
+            mockMessageHandler.AddMockResponse(catImageResponse, imageFinderUri);
+
+            return new HttpClient(mockMessageHandler);
+        }
+
+        private HttpClient PrepareHttpClient(List<string> breeds)
+        {
+            var baseUri = "https://api.thecatapi.com/v1/";
+            var breedsUri = $"{baseUri}breeds";
+
+            var mockMessageHandler = new MockResponseHandler();
+
+            var catBreedResponse = breeds
+                .Select(c => new CatBreedsResponse("", c))
+                .ToList();
+            mockMessageHandler.AddMockResponse(catBreedResponse, breedsUri);
+
+            return new HttpClient(mockMessageHandler);
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/Modules/ChuckNorrisJokes/ChuckServiceTests.cs
+++ b/MonkeyBot.UnitTests/Modules/ChuckNorrisJokes/ChuckServiceTests.cs
@@ -1,0 +1,85 @@
+﻿using MonkeyBot.Services;
+using MonkeyBot.UnitTests.Utils;
+using Moq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MonkeyBot.UnitTests.Modules.ChuckNorrisJokes
+{
+    public class ChuckServiceTests
+    {
+        private const string joke = "Chuck Norris doesn't need sudo, he just types \"Chuck Norris\" before his commands.";
+
+        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+        private readonly IChuckService chuckService;
+
+        public ChuckServiceTests()
+        {
+            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+
+            chuckService = new ChuckService(_mockHttpClientFactory.Object);
+        }
+
+        [Fact(DisplayName = "Should return Chuck Norris Joke")]
+        public async Task GetChuckJokeWithoutSpecifyingName()
+        {
+            // Arrange
+            var jokeUri = "http://api.icndb.com/jokes/random";
+            var httpClient = PrepareHttpClient(jokeUri, joke);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            // Act
+            var chuckJoke = await chuckService.GetChuckFactAsync();
+
+            // Assert
+            Assert.Equal(joke, chuckJoke);
+        }
+
+        [Fact(DisplayName = "Should return Chuck Norris Joke - Name Specified")]
+        public async Task GetChuckJokeAfterSpecifyingName()
+        {
+            // Arrange
+            var firstName = "Chuck";
+            var jokeUri = "http://api.icndb.com/jokes/random?firstName=" + firstName;
+            var httpClient = PrepareHttpClient(jokeUri, joke);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            // Act
+            var chuckJoke = await chuckService.GetChuckFactAsync(firstName);
+
+            // Assert
+            Assert.Equal(joke, chuckJoke);
+        }
+
+        [Fact(DisplayName = "Should return blank result on API Failure")]
+        public async Task GetEmptyChuckJokeAfterOnAPIFailure()
+        {
+            // Act
+            var chuckJoke = await chuckService.GetChuckFactAsync();
+
+            // Assert
+            Assert.True(string.IsNullOrWhiteSpace(chuckJoke));
+        }
+
+        [Fact(DisplayName = "Should return blank result on Empty Name")]
+        public async Task GetEmptyChuckJokeOnEmptyName()
+        {
+            // Act
+            var chuckJoke = await chuckService.GetChuckFactAsync("");
+
+            // Assert
+            Assert.True(string.IsNullOrWhiteSpace(chuckJoke));
+        }
+
+        private HttpClient PrepareHttpClient(string jokeUri, string joke)
+        {
+            var mockMessageHandler = new MockResponseHandler();
+
+            var chuckResponse = new ChuckResponse("success", new ChuckJoke(joke));
+            mockMessageHandler.AddMockResponse(chuckResponse, jokeUri);
+
+            return new HttpClient(mockMessageHandler);
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/Modules/DogPics/DogServiceTests.cs
+++ b/MonkeyBot.UnitTests/Modules/DogPics/DogServiceTests.cs
@@ -1,0 +1,130 @@
+﻿using MonkeyBot.Services;
+using MonkeyBot.UnitTests.Utils;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MonkeyBot.UnitTests.Modules.DogPics
+{
+    public class DogServiceTests
+    {
+        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+        private readonly IDogService dogService;
+
+        public DogServiceTests()
+        {
+            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+
+            dogService = new DogService(_mockHttpClientFactory.Object);
+        }
+
+        [Fact(DisplayName = "Should return a random image uri for the specified breed")]
+        public async Task ShouldReturnRandomImageUriForBreed()
+        {
+            // Arrange
+            var breed = "african";
+            var httpClient = PrepareHttpClient(breed);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var expectedUri = "https://images.dog.ceo/breeds/" + breed + ".jpg";
+
+            // Act
+            var uri = await dogService.GetRandomPictureUrlAsync(breed);
+
+            // Assert
+            Assert.Equal(new Uri(expectedUri), uri);
+        }
+
+        [Fact(DisplayName = "Should return a random image uri when no breed is specified")]
+        public async Task ShouldReturnRandomImageUri()
+        {
+            // Arrange
+            var httpClient = PrepareHttpClient();
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var expectedUri = "https://images.dog.ceo/breeds/random.jpg";
+
+            // Act
+            var uri = await dogService.GetRandomPictureUrlAsync();
+
+            // Assert
+            Assert.Equal(new Uri(expectedUri), uri);
+        }
+
+        [Fact(DisplayName = "Should return null image uri when Api call fails")]
+        public async Task ShouldReturnNullImageUriWhenCallFails()
+        {
+            // Act
+            var uri = await dogService.GetRandomPictureUrlAsync();
+
+            // Assert
+            Assert.Null(uri);
+        }
+
+        [Fact(DisplayName = "Should return a list of breeds")]
+        public async Task ShouldReturnListOfBreeds()
+        {
+            // Arrange
+            var expectedBreeds = new List<string> { "Australian", "Beagle" };
+            var httpClient = PrepareHttpClient(expectedBreeds);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            // Act
+            var breeds = await dogService.GetBreedsAsync();
+
+            // Assert
+            Assert.Equal(expectedBreeds, breeds);
+        }
+
+        [Fact(DisplayName = "Should return an empty list when API call fails")]
+        public async Task ShouldReturEmptyListOnException()
+        {
+            // Act
+            var breeds = await dogService.GetBreedsAsync();
+
+            // Assert
+            Assert.False(breeds.Any());
+        }
+
+        private HttpClient PrepareHttpClient(List<string> breeds)
+        {
+            var baseUri = "https://dog.ceo/api/";
+            var breedsUri = $"{baseUri}breeds/list/all";
+
+            var mockMessageHandler = new MockResponseHandler();
+
+            var dogBreedResponse = new DogBreedsResponse("success", breeds.ToDictionary(k => k, k => Enumerable.Empty<string>().ToList()));
+            mockMessageHandler.AddMockResponse(dogBreedResponse, breedsUri);
+
+            return new HttpClient(mockMessageHandler);
+        }
+
+        private HttpClient PrepareHttpClient(string breed)
+        {
+            var baseUri = "https://dog.ceo/api/";
+            var breedsUri = $"{baseUri}breed/{breed}/images/random";
+
+            var mockMessageHandler = new MockResponseHandler();
+
+            var dogBreedResponse = new DogResponse("success", "https://images.dog.ceo/breeds/" + breed + ".jpg");
+            mockMessageHandler.AddMockResponse(dogBreedResponse, breedsUri);
+
+            return new HttpClient(mockMessageHandler);
+        }
+
+        private HttpClient PrepareHttpClient()
+        {
+            var baseUri = "https://dog.ceo/api/";
+            var breedsUri = $"{baseUri}breeds/image/random";
+
+            var mockMessageHandler = new MockResponseHandler();
+
+            var dogBreedResponse = new DogResponse("success", "https://images.dog.ceo/breeds/random.jpg");
+            mockMessageHandler.AddMockResponse(dogBreedResponse, breedsUri);
+
+            return new HttpClient(mockMessageHandler);
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/Modules/Xkcd/XkcdServiceTests.cs
+++ b/MonkeyBot.UnitTests/Modules/Xkcd/XkcdServiceTests.cs
@@ -1,0 +1,144 @@
+﻿using MonkeyBot.Services;
+using MonkeyBot.UnitTests.Utils;
+using Moq;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MonkeyBot.UnitTests.Modules.Xkcd
+{
+    public class XkcdServiceTests
+    {
+        private const string _baseUri = "https://xkcd.com/";
+        private const string _infoJson = "info.0.json";
+
+        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+        private readonly IXkcdService xkcdService;
+
+        public XkcdServiceTests()
+        {
+            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+
+            xkcdService = new XkcdService(_mockHttpClientFactory.Object);
+        }
+
+        [Fact(DisplayName = "Should get the latest comic")]
+        public async Task ShouldGetLatestComic()
+        {
+            // Arrange
+            var number = 69;
+            var latestResponseHandler = PrepareMockResponseHandlerForLatest(number);
+            var httpClient = PrepareHttpClient(latestResponseHandler);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            var xkcdResponse = PrepareXkcdResponse(number);
+
+            // Act
+            var latestComic = await xkcdService.GetLatestComicAsync();
+
+            // Assert
+            PropertyMatcher.Match(xkcdResponse, latestComic);
+        }
+
+        [Fact(DisplayName = "Should return null on call failure")]
+        public async Task ShouldReturnNullOnCallFail()
+        {
+            // Act
+            var latestComic = await xkcdService.GetLatestComicAsync();
+
+            // Assert
+            Assert.Null(latestComic);
+        }
+
+        [Theory(DisplayName = "Should throw Argument Null Exception on invalid number")]
+        [InlineData(-1)]
+        [InlineData(404)]
+        [InlineData(790)]
+        public async Task ShouldthrowExceptionWhenInvalidNumberIsPassed(int number)
+        {
+            // Arrange
+            var maxNumber = 690;
+            var latestResponseHandler = PrepareMockResponseHandlerForLatest(maxNumber);
+            var httpClient = PrepareHttpClient(latestResponseHandler);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            Func<Task> action = async () => await xkcdService.GetComicAsync(number);
+
+            // Act and Assert
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(action);
+        }
+
+        [Fact(DisplayName = "Should return the proper comic by number")]
+        public async Task GetComicByNumber()
+        {
+            // Arrange
+            var maxNumber = 690;
+            var comicNumber = 420;
+            var latestResponseHandler = PrepareMockResponseHandlerForLatest(maxNumber);
+            PrepareMockResponseHandler(latestResponseHandler, comicNumber);
+            var httpClient = PrepareHttpClient(latestResponseHandler);
+            _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            var expectedComic = PrepareXkcdResponse(comicNumber);
+
+            // Act
+            var comic = await xkcdService.GetComicAsync(comicNumber);
+
+            // Assert
+            PropertyMatcher.Match(expectedComic, comic);
+        }
+
+        [Fact]
+        public void ShouldreturnProperComicUrl()
+        {
+            // Arrange
+            var comicNumber = 88;
+            var expectedUri = _baseUri + comicNumber;
+
+            // Act
+            var comicUri = xkcdService.GetComicUrl(comicNumber);
+
+            // Assert
+            Assert.Equal(new Uri(expectedUri), comicUri);
+        }
+
+        private MockResponseHandler PrepareMockResponseHandlerForLatest(int number)
+        {
+            var mockResponseHandler = new MockResponseHandler();
+            var uri = _baseUri + _infoJson;
+            var xkcdResponse = PrepareXkcdResponse(number);
+            mockResponseHandler.AddMockResponse(xkcdResponse, uri);
+
+            return mockResponseHandler;
+        }
+
+        private void PrepareMockResponseHandler(MockResponseHandler mockResponseHandler, int number)
+        {
+            var uri = _baseUri + number + "/" + _infoJson;
+            var xkcdResponse = PrepareXkcdResponse(number);
+            mockResponseHandler.AddMockResponse(xkcdResponse, uri);
+        }
+
+        private static XkcdResponse PrepareXkcdResponse(int number)
+        {
+            return new XkcdResponse
+            {
+                Number = number,
+                Month = "3",
+                Link = "",
+                Year = "2008",
+                News = "",
+                SafeTitle = "Convincing Pickup Line",
+                Transcript = "",
+                ImgUrl = new Uri(@"https://imgs.xkcd.com/comics/convincing_pickup_line.png"),
+                Day = "31"
+            };
+        }
+
+        private HttpClient PrepareHttpClient(MockResponseHandler mockResponseHandler)
+        {
+            return new HttpClient(mockResponseHandler);
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/MonkeyBot.UnitTests.csproj
+++ b/MonkeyBot.UnitTests/MonkeyBot.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MockQueryable.Moq" Version="5.0.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MonkeyBot\MonkeyBot.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MonkeyBot.UnitTests/Services/GuildServiceTests.cs
+++ b/MonkeyBot.UnitTests/Services/GuildServiceTests.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.EntityFrameworkCore;
+using MonkeyBot.Database;
+using MonkeyBot.Models;
+using MonkeyBot.Services;
+using MonkeyBot.UnitTests.Utils;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MonkeyBot.UnitTests.Services
+{
+    public class GuildServiceTests
+    {
+        private readonly Mock<MonkeyDBContext> _monkeyDbContext;
+        private readonly Mock<DbSet<GuildConfig>> _mockGuildConfig;
+        private readonly IGuildService guildService;
+
+        public GuildServiceTests()
+        {
+            _monkeyDbContext = new Mock<MonkeyDBContext>();
+
+            var guildConfigs = PrepareGuildConfigs(100, 4);
+            _mockGuildConfig = _monkeyDbContext.SetDbSetData(guildConfigs, c => c.GuildConfigs);
+
+            guildService = new GuildService(_monkeyDbContext.Object);
+        }
+
+        [Fact(DisplayName = "Should create GuildConfig if one does not exist for the given guildId")]
+        public async Task CreateConfigIfOneDoesNotExist()
+        {
+            // Arrange
+            var guildId = (ulong)1000L;
+            var expectedResult = new GuildConfig { GuildID = guildId };
+
+            // Act
+            var result = await guildService.GetOrCreateConfigAsync(guildId);
+
+            // Assert
+            PropertyMatcher.Match(expectedResult, result);
+            _mockGuildConfig.Verify(d => d.Add(Match.Create<GuildConfig>(g => g.GuildID == guildId)), Times.Once);
+            _monkeyDbContext.Verify(c => c.SaveChangesAsync(default), Times.Once);
+        }
+
+        [Fact(DisplayName = "Should return existing GuildConfig if found")]
+        public async Task ReturnExistingGuildConfigIfFound()
+        {
+            // Arrange
+            var guildId = (ulong)100L;
+            var expectedResult = new GuildConfig { GuildID = guildId, CommandPrefix = $"CommandPrefix-{guildId}" };
+
+            // Act
+            var result = await guildService.GetOrCreateConfigAsync(guildId);
+
+            // Assert
+            PropertyMatcher.Match(expectedResult, result);
+            _mockGuildConfig.Verify(d => d.Add(It.IsAny<GuildConfig>()), Times.Never);
+            _monkeyDbContext.Verify(c => c.SaveChangesAsync(default), Times.Never);
+        }
+
+        [Fact(DisplayName = "Should update GuildConfig")]
+        public async Task ShouldUpdateGuildConfig()
+        {
+            // Arrange
+            var guildId = (ulong)100L;
+            var guildConfig = new GuildConfig { GuildID = guildId };
+
+            // Act
+            await guildService.UpdateConfigAsync(guildConfig);
+
+            // Assert
+            _mockGuildConfig.Verify(d => d.Update(Match.Create<GuildConfig>(g => g.GuildID == guildId)), Times.Once);
+            _monkeyDbContext.Verify(c => c.SaveChangesAsync(default), Times.Once);
+        }
+
+        [Fact(DisplayName = "Should remove GuildConfig if found")]
+        public async Task ShouldRemoveGuildConfigIfFound()
+        {
+            // Arrange
+            var guildId = (ulong)100L;
+
+            // Act
+            await guildService.RemoveConfigAsync(guildId);
+
+            // Assert
+            _mockGuildConfig.Verify(d => d.Remove(Match.Create<GuildConfig>(g => g.GuildID == guildId)), Times.Once);
+            _monkeyDbContext.Verify(c => c.SaveChangesAsync(default), Times.Once);
+        }
+
+        [Fact(DisplayName = "Should not remove GuildConfig if not found")]
+        public async Task ShouldNotRemoveGuildConfigIfNotFound()
+        {
+            // Arrange
+            var guildId = (ulong)1000L;
+
+            // Act
+            await guildService.RemoveConfigAsync(guildId);
+
+            // Assert
+            _mockGuildConfig.Verify(d => d.Remove(Match.Create<GuildConfig>(g => g.GuildID == guildId)), Times.Never);
+            _monkeyDbContext.Verify(c => c.SaveChangesAsync(default), Times.Never);
+        }
+
+        [Fact(DisplayName = "Should return the right CommandPrefix for an existing GuildConfig")]
+        public async Task ShouldReturnTheRightPrefixForAnExistingGuildConfig()
+        {
+            // Arrange
+            var guildId = (ulong)100L;
+
+            // Act
+            var result = await guildService.GetPrefixForGuild(guildId);
+
+            // Assert
+            Assert.Equal($"CommandPrefix-{guildId}", result);
+        }
+
+        [Fact(DisplayName = "Should return the default command prefix for new GuildConfig")]
+        public async Task ShouldReturnTheDefaultCommandPrefixForNewGuildConfig()
+        {
+            // Arrange
+            var guildId = (ulong)1000L;
+
+            // Act
+            var result = await guildService.GetPrefixForGuild(guildId);
+
+            // Assert
+            Assert.Equal(GuildConfig.DefaultPrefix, result);
+        }
+
+        private static List<GuildConfig> PrepareGuildConfigs(int startingValue, int count)
+        {
+            return Enumerable.Range(startingValue, count)
+                .Select(gc => new GuildConfig { GuildID = (ulong)gc, CommandPrefix = $"CommandPrefix-{gc}" })
+                .ToList();
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/Utils/DbContextExtensions.cs
+++ b/MonkeyBot.UnitTests/Utils/DbContextExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace MonkeyBot.UnitTests.Utils
+{
+    internal static class DbContextExtensions
+    {
+        internal static Mock<DbSet<TEnt>> SetDbSetData<TEnt, TCon>(this Mock<TCon> dbMock, IList<TEnt> list, Expression<Func<TCon, DbSet<TEnt>>> expression) where TEnt : class
+                                                                                                                  where TCon: DbContext
+        {
+            var clonedList = list.ToList();
+            var mockDbSet = clonedList.AsQueryable().BuildMockDbSet();
+
+            dbMock.Setup(expression).Returns(mockDbSet.Object);
+
+            return mockDbSet;
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/Utils/MockResponseHandler.cs
+++ b/MonkeyBot.UnitTests/Utils/MockResponseHandler.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MonkeyBot.UnitTests.Utils
+{
+    public class MockResponseHandler : DelegatingHandler
+    {
+        private readonly Dictionary<Uri, HttpResponseMessage> _fakeResponses = new Dictionary<Uri, HttpResponseMessage>();
+
+        public void AddMockResponse<T>(List<T> data, string requestUri)
+        {
+            AddMockResponse(new Uri(requestUri), new HttpResponseMessage(HttpStatusCode.OK), JsonSerializer.Serialize(data));
+        }
+
+        public void AddMockResponse<T>(T data, string requestUri)
+        {
+            AddMockResponse(new Uri(requestUri), new HttpResponseMessage(HttpStatusCode.OK), JsonSerializer.Serialize(data));
+        }
+
+        public void AddMockResponse(Uri uri, HttpResponseMessage responseMessage, string content = "")
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                responseMessage.Content = new StringContent(content, Encoding.UTF8, "application/json");
+            }
+            _fakeResponses.Add(uri, responseMessage);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var emptyContent = string.Empty;
+
+            return Task.FromResult(_fakeResponses.ContainsKey(request.RequestUri) ?
+                _fakeResponses[request.RequestUri] :
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                    Content = new StringContent(emptyContent)
+                });
+        }
+
+    }
+}

--- a/MonkeyBot.UnitTests/Utils/PropertyMatcher.cs
+++ b/MonkeyBot.UnitTests/Utils/PropertyMatcher.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace MonkeyBot.UnitTests.Utils
+{
+    internal static class PropertyMatcher
+    {
+        private static IDictionary<string, PropertyInfo[]> _memo = new Dictionary<string, PropertyInfo[]>();
+
+        internal static void Match<T>(T expected, T actual)
+        {
+            var properties = GetProperties<T>();
+            var validationErrors = new List<string>();
+            foreach (var property in properties)
+            {
+                var expectedValue = property.GetValue(expected);
+                var actualValue = property.GetValue(actual);
+
+                if (expectedValue == null && actualValue == null)
+                {
+                    continue;
+                }
+
+                if (expectedValue == null || actualValue == null || !expectedValue.Equals(actualValue))
+                {
+                    validationErrors.Add($"Property {property.Name} Expected {expectedValue} but was {actualValue}");
+                }
+            }
+            Assert.True(!validationErrors.Any(), string.Join(Environment.NewLine, validationErrors));
+        }
+
+        private static PropertyInfo[] GetProperties<T>()
+        {
+            var entityType = typeof(T);
+            if(!_memo.TryGetValue(entityType.FullName, out var properties))
+            {
+                var entityProperties = entityType.GetProperties();
+                _memo.Add(entityType.FullName, entityProperties);
+
+                return entityProperties;
+            }
+            return properties;
+        }
+    }
+}

--- a/MonkeyBot.UnitTests/app.config
+++ b/MonkeyBot.UnitTests/app.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.methodDisplay" value="method" />
+    <add key="xunit.methodDisplayOptions" value="all" />
+  </appSettings>
+</configuration>

--- a/MonkeyBot.sln
+++ b/MonkeyBot.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.15
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyBot", "MonkeyBot\MonkeyBot.csproj", "{16306D0F-7B2A-4CEA-8138-DC0EC38CE217}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonkeyBot.UnitTests", "MonkeyBot.UnitTests\MonkeyBot.UnitTests.csproj", "{C4542675-042C-4ACB-A29A-33E3D4CCFEE4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{16306D0F-7B2A-4CEA-8138-DC0EC38CE217}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16306D0F-7B2A-4CEA-8138-DC0EC38CE217}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16306D0F-7B2A-4CEA-8138-DC0EC38CE217}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4542675-042C-4ACB-A29A-33E3D4CCFEE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4542675-042C-4ACB-A29A-33E3D4CCFEE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4542675-042C-4ACB-A29A-33E3D4CCFEE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4542675-042C-4ACB-A29A-33E3D4CCFEE4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {74645538-F2EE-4C3A-8C02-3E4F0CD5CDBC}
 	EndGlobalSection
 EndGlobal

--- a/MonkeyBot/Database/MonkeyDBContext.cs
+++ b/MonkeyBot/Database/MonkeyDBContext.cs
@@ -10,7 +10,7 @@ namespace MonkeyBot.Database
     public class MonkeyDBContext : DbContext
     {
         public DbSet<BenzenFact> BenzenFacts { get; set; }
-        public DbSet<GuildConfig> GuildConfigs { get; set; }
+        public virtual DbSet<GuildConfig> GuildConfigs { get; set; }
         public DbSet<TriviaScore> TriviaScores { get; set; }
         public DbSet<Announcement> Announcements { get; set; }
         public DbSet<Feed> Feeds { get; set; }

--- a/MonkeyBot/Services/GuildService.cs
+++ b/MonkeyBot/Services/GuildService.cs
@@ -35,7 +35,7 @@ namespace MonkeyBot.Services
         public async Task RemoveConfigAsync(ulong guildId)
         {
             GuildConfig config = await _dbContext.GuildConfigs.SingleOrDefaultAsync(c => c.GuildID == guildId);
-            if (config == null)
+            if (config != null)
             {
                 _dbContext.GuildConfigs.Remove(config);
                 await _dbContext.SaveChangesAsync();


### PR DESCRIPTION
Brings code coverage to `5.1%`.

![image](https://user-images.githubusercontent.com/12110372/136262404-fd64d21c-ea26-42e1-907d-606ee226da8f.png)

`DiscordClient` is a sealed class. This makes mocking it a pain in unit tests.  
Isolation frameworks can probably help deal with it but I'm yet to find an open-source one that works.
Another option to be considered is wrapping `DiscordClient` in a wrapper class with an interface.
